### PR TITLE
Updates session's ID key to match codealong

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,11 +47,11 @@ class ApplicationController < Sinatra::Base
 
 	helpers do
 		def logged_in?
-			!!session[:id]
+			!!session[:user_id]
 		end
 
 		def current_user
-			User.find(session[:id])
+			User.find(session[:user_id])
 		end
 	end
 


### PR DESCRIPTION
The README uses a `session[:id]` but the helper methods that come pre-baked into this lab use `session[:user_id]` causing a failure when the `/success` route calls the `logged_in?` method. Updated the pre-written code to match the expected README values. (Compare the screenshots attached.)

**From the codealong README:**
![image](https://user-images.githubusercontent.com/2465794/76712646-c3b3ae80-66e8-11ea-84a5-cb1cd1c796a9.png) 

**From the pre-built code for the helper methods:**
![image](https://user-images.githubusercontent.com/2465794/76712655-d201ca80-66e8-11ea-9ed7-1772336465fa.png)

